### PR TITLE
Mudanças no gradiente

### DIFF
--- a/lib/telas/home/home.dart
+++ b/lib/telas/home/home.dart
@@ -73,12 +73,13 @@ class HomeState extends State<Home> {
     return Container(
       height: 200,
       decoration: BoxDecoration(
-          gradient: LinearGradient(
-              begin: FractionalOffset.topCenter,
-              end: FractionalOffset.bottomCenter,
+          gradient: RadialGradient(
+           center: Alignment(0.8,0.8),   
+              focal: Alignment(1,1),
+              radius: 0.8,
               colors: [
-            Colors.transparent,
-            Colors.black.withOpacity(0.7),
+                Colors.black.withOpacity(0.6),
+                Colors.transparent.withOpacity(0.05),
           ])),
     );
   }
@@ -86,8 +87,8 @@ class HomeState extends State<Home> {
   Widget _construirTextoCard(texto) {
     return Positioned(
       bottom: 10,
-      left: 10,
-      child: Text(texto, style: TextStyle(fontSize: 20, color: Colors.white)),
+      right: 10,
+      child: Text(texto, style: TextStyle(fontSize: 27, color: Colors.white)),
     );
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -102,13 +102,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.6.4"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.8.0+1"
   petitparser:
     dependency: transitive
     description:
@@ -169,7 +162,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.11"
+    version: "0.2.15"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
O que acha de mudar a cor de **gradiente conforme os tipos** de pokemon? (exemplo: um pokemon do tipo elétrico possuir o gradiente amarelo).
Ainda não sei a melhor forma de implementar isso, mas dando uma pesquisada podemos usar o próprio JSON e **inputar as cores conforme os tipos** ou usar o **palette generator do flutter** a partir da imagem já contida no card do Pokemon.